### PR TITLE
Added socket timeouts to client and server

### DIFF
--- a/src/android/com/perfectco/cordova/TlsPskClientSocket.java
+++ b/src/android/com/perfectco/cordova/TlsPskClientSocket.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.net.Socket;
 
 public class TlsPskClientSocket extends TlsPskSocket {
+  private static int SOCKET_TIMEOUT_MS = 5000;
   private final TlsClient client;
 
   public TlsPskClientSocket(byte[] key) {
@@ -21,6 +22,7 @@ public class TlsPskClientSocket extends TlsPskSocket {
     }
 
     Socket socket = new Socket(host, port);
+    socket.setSoTimeout(SOCKET_TIMEOUT_MS);
     TlsClientProtocol protocol = new TlsClientProtocol(socket.getInputStream(), socket.getOutputStream());
     protocol.connect(client);
     connected(socket, protocol);

--- a/src/android/com/perfectco/cordova/TlsPskServer.java
+++ b/src/android/com/perfectco/cordova/TlsPskServer.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 
 public class TlsPskServer {
+  private static int SOCKET_TIMEOUT_MS = 5000;
   private final UUID uuid = UUID.randomUUID();
   private final TlsServer server;
 
@@ -40,6 +41,7 @@ public class TlsPskServer {
     }
 
     socket = new ServerSocket(port);
+    socket.setSoTimeout(SOCKET_TIMEOUT_MS);
 
     acceptThread = new Thread(() -> {
       while (!Thread.currentThread().isInterrupted() && !socket.isClosed()) {


### PR DESCRIPTION
Part of PQ-1131. Rather than the default 30 min. timeout, this sets socket timeouts to 5 seconds.